### PR TITLE
Fix: Add missing documentation for public items (RS-D1001)

### DIFF
--- a/record-lib/src/lib.rs
+++ b/record-lib/src/lib.rs
@@ -1,1 +1,3 @@
+//! This library provides functionalities to record internet radio streams
+//! from various Japanese radio services, including Radiko, AGQR, Onsen, and Hibiki Radio.
 pub mod record;

--- a/record-lib/src/record.rs
+++ b/record-lib/src/record.rs
@@ -1,12 +1,36 @@
+/// Module for handling agqr.jp radio recordings.
 pub mod ag;
+/// Module for handling hibiki-radio.jp radio recordings.
 pub mod hibiki;
+/// Module for handling onsen.ag radio recordings.
 pub mod onsen;
+/// Module for handling radiko.jp radio recordings.
 pub mod radiko;
 
 use chrono::{DateTime, Duration, Local};
 
 use std::process::ExitStatus;
+
+/// A trait for recording internet radio programs.
 pub trait Record {
+    /// Creates a new recording task.
+    ///
+    /// # Arguments
+    ///
+    /// * `title` - The title of the program.
+    /// * `start_datetime` - The start date and time of the recording.
+    /// * `end_datetime` - The end date and time of the recording.
     fn new(title: &str, start_datetime: &DateTime<Local>, end_datetime: &DateTime<Local>) -> Self;
+
+    /// Starts the recording process.
+    ///
+    /// # Arguments
+    ///
+    /// * `output_path` - The path where the recorded file will be saved.
+    /// * `duration` - The duration of the recording.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` indicating whether the recording was successful or an I/O error occurred.
     fn record(self, output_path: String, duration: Duration) -> Result<ExitStatus, std::io::Error>;
 }

--- a/record-lib/src/record/ag.rs
+++ b/record-lib/src/record/ag.rs
@@ -10,10 +10,14 @@ use std::process::Command;
 use std::process::ExitStatus;
 use std::{env, fs, str};
 
+/// Represents an AGQR program recording task.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Ag {
+    /// The title of the program.
     pub title: String,
+    /// The start date and time of the program.
     pub start_datetime: DateTime<Local>,
+    /// The end date and time of the program.
     pub end_datetime: DateTime<Local>,
 }
 
@@ -109,6 +113,17 @@ impl Ag {
         };
     }
 
+    /// Creates a new `Ag` instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `title` - The title of the program.
+    /// * `start_datetime` - The start date and time of the program.
+    /// * `end_datetime` - The end date and time of the program.
+    ///
+    /// # Returns
+    ///
+    /// A new `Ag` instance.
     pub fn new(
         title: &str,
         start_datetime: &DateTime<Local>,
@@ -120,6 +135,16 @@ impl Ag {
             end_datetime: *end_datetime,
         }
     }
+
+    /// Fetches the HTML content of the AGQR daily program schedule page.
+    ///
+    /// # Returns
+    ///
+    /// A `reqwest::blocking::Response` containing the HTML content.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the HTTP request fails.
     pub fn get_html() -> reqwest::blocking::Response {
         return match reqwest::blocking::get(
             "https://www.joqr.co.jp/qr/agdailyprogram/agdailyprogram.html",
@@ -131,6 +156,20 @@ impl Ag {
             }
         };
     }
+
+    /// Parses the HTML content of the AGQR daily program schedule page and extracts program information.
+    ///
+    /// # Arguments
+    ///
+    /// * `get_result` - A `reqwest::blocking::Response` containing the HTML content.
+    ///
+    /// # Returns
+    ///
+    /// A vector of `Ag` instances representing the programs in the schedule.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the HTML content cannot be parsed or if expected elements are not found.
     pub fn html_parse(get_result: reqwest::blocking::Response) -> Vec<Ag> {
         let body = match get_result.text() {
             Ok(n) => n,
@@ -188,6 +227,11 @@ impl Ag {
         arr
     }
 
+    /// Initializes a list of `Ag` tasks by fetching and parsing the AGQR daily program schedule.
+    ///
+    /// # Returns
+    ///
+    /// A vector of `Ag` instances representing the programs in the schedule.
     pub fn init() -> Vec<Ag> {
         let get_result = Ag::get_html();
         Ag::html_parse(get_result)

--- a/record-lib/src/record/hibiki.rs
+++ b/record-lib/src/record/hibiki.rs
@@ -43,15 +43,31 @@ struct HibikiEpisode {
     episode: Option<HibikiEpisodeId>,
 }
 
+/// Represents the JSON structure for a Hibiki radio program.
 #[derive(Deserialize, Debug)]
 pub struct HibikiJson {
+    /// The access ID of the program.
     access_id: String,
     //cast: String,
+    /// The ID of the latest episode.
     latest_episode_id: Option<u32>,
+    /// The name of the latest episode.
     latest_episode_name: Option<String>,
+    /// The URL of the program's PC image.
     pc_image_url: Option<String>,
+    /// The name of the program.
     name: String,
 }
+
+/// Fetches data from the Hibiki API.
+///
+/// # Arguments
+///
+/// * `url` - The API endpoint URL.
+///
+/// # Returns
+///
+/// A `reqwest::Result` containing the API response.
 pub fn get_api(url: &str) -> reqwest::Result<Response> {
     let client = reqwest::blocking::Client::new();
 
@@ -100,6 +116,15 @@ impl HibikiVideo {
     }
 }
 
+/// Formats a filename to replace characters that are forbidden in filenames.
+///
+/// # Arguments
+///
+/// * `filename` - The original filename.
+///
+/// # Returns
+///
+/// A new string with forbidden characters replaced.
 pub fn format_forbidden_char(filename: &str) -> String {
     // 禁止文字(半角記号)
     // let cannot_used_file_name = "\\/:*?`\"><|";
@@ -122,6 +147,11 @@ fn pass_format_char() {
     assert_eq!(format_forbidden_char("Fate/Test"), "Fate／Test")
 }
 static RS_NET_ARCHIVE_PATH: &str = "RS_NET_ARCHIVE_PATH";
+
+/// Records Hibiki radio programs.
+///
+/// This function fetches the list of programs, checks for new episodes,
+/// and downloads them using ffmpeg.
 pub fn record() {
     let page = 1;
 

--- a/record-lib/src/record/onsen.rs
+++ b/record-lib/src/record/onsen.rs
@@ -8,31 +8,47 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
+/// Represents the contents of an Onsen program episode.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OnsenProgramContents {
+    /// The ID of the program content.
     id: u32,
+    /// The title of the program content (episode).
     title: String,
+    /// Indicates if this is the latest episode.
     latest: bool,
+    /// Indicates if this is a premium episode.
     premium: bool,
+    /// The delivery date of the episode.
     deliver_date: Option<String>,
+    /// The streaming URL for the episode.
     streaming_url: Option<String>,
 }
+
+/// Represents a performer on an Onsen program.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OnsenPerformer {
+    /// The ID of the performer.
     id: u32,
+    /// The name of the performer.
     name: String,
 }
+
+/// Represents an Onsen radio program.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OnsenProgram {
     // "category_list",
     // #[serde(borrow)]
+    /// A list of contents (episodes) for the program.
     contents: Vec<OnsenProgramContents>,
     // #[serde(borrow)]
+    /// A list of performers for the program.
     performers: Vec<OnsenPerformer>, // "copyright",
     // "delivery_day_of_week",
     // "delivery_interval",
     // "directory_name",
     // "display",
+    /// The ID of the program.
     id: u32,
     // "image",
     // "list",
@@ -43,11 +59,16 @@ pub struct OnsenProgram {
     // "related_programs",
     // "show_contents_count",
     // "sponsor_name",
+    /// The title of the program.
     pub title: String,
     // "updated"
 }
 impl OnsenProgram {
     const RS_NET_ARCHIVE_PATH: &'static str = "RS_NET_ARCHIVE_PATH";
+    /// Records the episodes of the Onsen program.
+    ///
+    /// This function iterates through the program's contents (episodes) and downloads
+    /// any available streams using ffmpeg.
     pub fn record(&self) {
         let archive_path = match env::var(Self::RS_NET_ARCHIVE_PATH) {
             Ok(n) => {
@@ -135,6 +156,16 @@ impl OnsenProgram {
             };
         }
     }
+
+    /// Initializes a list of `OnsenProgram` tasks by fetching data from the Onsen API.
+    ///
+    /// # Returns
+    ///
+    /// A vector of `OnsenProgram` instances.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the API request or JSON parsing fails.
     pub fn init() -> Vec<OnsenProgram> {
         let client = reqwest::blocking::Client::new();
         match client.get("https://www.onsen.ag/web_api/programs").send() {

--- a/record-lib/src/record/radiko.rs
+++ b/record-lib/src/record/radiko.rs
@@ -17,25 +17,32 @@ use std::{env, fs};
 // #[macro_use]
 // extern crate serde_derive;
 
+/// Represents the overall Radiko data structure.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Radiko<'a> {
     ttl: u32,
     srvtime: u32,
     #[serde(borrow)]
+    /// Holds information about the stations.
     pub stations: Stations<'a>,
 }
 
+/// Represents a collection of stations.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Stations<'a> {
     #[serde(borrow)]
+    /// Holds information about a single station.
     pub station: Station<'a>,
 }
+
+/// Represents a single station.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Station<'a> {
     id: ID,
     #[serde(default)]
     name: Cow<'a, str>,
     #[serde(borrow)]
+    /// Holds the program schedule for the station.
     pub scd: Scd<'a>,
 }
 #[allow(clippy::upper_case_acronyms)]
@@ -46,60 +53,88 @@ enum ID {
     BAYFM78,
 }
 
+/// Represents the program schedule for a station.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Scd<'a> {
     #[serde(borrow)]
+    /// Holds a list of programs.
     pub progs: Vec<Progs<'a>>,
 }
 
+/// Represents a collection of programs.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Progs<'a> {
     #[serde(borrow)]
     #[serde(rename = "$value")]
+    /// Holds a list of program sets, which can be either a date or a program.
     pub list: Vec<Progset<'a>>,
 }
+
+/// Represents either a date or a program in the schedule.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum Progset<'a> {
+    /// Represents a date in the schedule.
     Date(ProgDate),
+    /// Represents a program in the schedule.
     #[serde(borrow)]
     Prog(Program<'a>),
 }
+
+/// Represents a date in the program schedule.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct ProgDate {
     #[serde(rename = "$value")]
     value: u32,
 }
 
+/// Represents a single program.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Program<'a> {
+    /// Start time of the program (YYYYMMDDHHMMSS).
     pub ft: Cow<'a, str>,
+    /// End time of the program (YYYYMMDDHHMMSS).
     pub to: Cow<'a, str>,
+    /// Start time of the program (HHMM).
     pub ftl: Cow<'a, str>,
+    /// End time of the program (HHMM).
     pub tol: Cow<'a, str>,
+    /// Duration of the program in seconds.
     pub dur: u32,
+    /// Title of the program.
     pub title: Cow<'a, str>,
     // pfm: Option<&'a str>,
 }
+
+/// Represents the streaming URL for a channel.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct ChStreamingUrl {
     // #[serde(borrow)]
     #[serde(rename = "$value")]
     list: Vec<Urlset>,
 }
+
+/// Represents a set of URLs, typically for streaming.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum Urlset {
     // #[serde(borrow)]
+    /// Represents a streaming URL.
     Url(StreamingUrl),
 }
+
+/// Represents a streaming URL with area restriction information.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct StreamingUrl {
+    /// Indicates if the stream is area-free (0 for false, 1 for true).
     pub areafree: u8,
+    /// The URL for creating the playlist.
     pub playlist_create_url: String,
     // media_url_path: String,
     // playlist_url_path: String,
 }
+
+/// Represents a Radiko recording task.
 #[derive(Debug, PartialEq)]
 pub struct RecordRadiko {
     title: String,
@@ -108,6 +143,15 @@ pub struct RecordRadiko {
     url: String,
 }
 impl RecordRadiko {
+    /// Initializes a list of `RecordRadiko` tasks for a given channel.
+    ///
+    /// # Arguments
+    ///
+    /// * `ch` - The channel ID (e.g., "QRR", "LFR").
+    ///
+    /// # Returns
+    ///
+    /// A vector of `RecordRadiko` tasks.
     pub fn init(ch: &str) -> Vec<Self> {
         let radiko = Radiko::init(ch);
         let streaming_url = ChStreamingUrl::init(ch);
@@ -139,6 +183,13 @@ impl RecordRadiko {
         hoge
     }
     const RS_NET_ARCHIVE_PATH: &'static str = "RS_NET_ARCHIVE_PATH";
+    /// Downloads the Radiko program.
+    ///
+    /// This function performs the authentication steps and then uses ffmpeg to download the stream.
+    ///
+    /// # Returns
+    ///
+    /// The exit status of the ffmpeg command.
     pub fn download(&self) -> ExitStatus {
         let resp = RecordRadiko::auth1();
         let header_str = resp.headers();
@@ -236,6 +287,16 @@ impl RecordRadiko {
         }
         output.status
     }
+
+    /// Formats a filename to replace characters that are forbidden in filenames.
+    ///
+    /// # Arguments
+    ///
+    /// * `filename` - The original filename.
+    ///
+    /// # Returns
+    ///
+    /// A new string with forbidden characters replaced.
     pub fn format_forbidden_char(filename: &str) -> String {
         // 禁止文字(半角記号)
         // let cannot_used_file_name = "\\/:*?`\"><|";
@@ -319,6 +380,15 @@ impl RecordRadiko {
 }
 
 impl Radiko<'_> {
+    /// Initializes Radiko data for a given channel.
+    ///
+    /// # Arguments
+    ///
+    /// * `ch` - The channel ID (e.g., "QRR", "LFR").
+    ///
+    /// # Returns
+    ///
+    /// A `Radiko` struct containing station and program information.
     pub fn init(ch: &str) -> Self {
         let m = get_program_dom(ch);
         let radiko: Radiko = match from_str(match &m.text() {
@@ -341,6 +411,17 @@ impl Radiko<'_> {
 }
 
 impl ChStreamingUrl {
+    /// Gets the streaming URL from the `ChStreamingUrl` struct.
+    ///
+    /// It iterates through the list of URLs and returns the first area-free M3U8 playlist URL.
+    ///
+    /// # Returns
+    ///
+    /// The streaming URL as a string.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no suitable streaming URL is found.
     pub fn get_streaming_url(&self) -> String {
         debug!("{:#?}", self.list);
         for i in &self.list[0..1] {
@@ -359,6 +440,16 @@ impl ChStreamingUrl {
 
         //url.to_string()
     }
+
+    /// Initializes `ChStreamingUrl` for a given channel.
+    ///
+    /// # Arguments
+    ///
+    /// * `ch` - The channel ID (e.g., "QRR", "LFR").
+    ///
+    /// # Returns
+    ///
+    /// A `ChStreamingUrl` struct containing streaming URL information.
     pub fn init(ch: &str) -> ChStreamingUrl {
         let client = Client::new();
         let url = format!("http://radiko.jp/v2/station/stream_smh_multi/{ch}.xml");
@@ -386,6 +477,16 @@ impl ChStreamingUrl {
         }
     }
 }
+
+/// Fetches the program DOM for a given channel.
+///
+/// # Arguments
+///
+/// * `ch` - The channel ID (e.g., "QRR", "LFR").
+///
+/// # Returns
+///
+/// A `reqwest::blocking::Response` containing the program DOM.
 pub fn get_program_dom(ch: &str) -> Response {
     let client = Client::new();
     let url = format!("http://radiko.jp/v2/api/program/station/weekly?station_id={ch}");
@@ -400,6 +501,15 @@ pub fn get_program_dom(ch: &str) -> Response {
     }
 }
 impl Program<'_> {
+    /// Parses the program's start time string into a `DateTime<Local>` object.
+    ///
+    /// # Returns
+    ///
+    /// A `DateTime<Local>` representation of the program's start time.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the time string cannot be parsed.
     pub fn parse_time(&self) -> DateTime<Local> {
         return match Local.datetime_from_str(self.ft.as_ref(), "%Y%m%d%H%M%S") {
             Ok(m) => m,


### PR DESCRIPTION
This commit addresses the DeepSource issue RS-D1001 by adding documentation comments (/// or //!) to all public items across the `record-lib` crate.

The following files and their respective public structs, functions, methods, traits, and modules have been documented:
- record-lib/src/record/radiko.rs
- record-lib/src/record/ag.rs
- record-lib/src/record/hibiki.rs
- record-lib/src/record/onsen.rs
- record-lib/src/record.rs
- record-lib/src/lib.rs (crate-level documentation)

These changes improve code clarity and maintainability by ensuring that all publicly exposed parts of the library are well-documented.


FIXES #166 