### PR TITLE
Fix: Use static string for env var key in example

### DIFF
--- a/record-lib/examples/hibiki-toybox.rs
+++ b/record-lib/examples/hibiki-toybox.rs
@@ -2,7 +2,8 @@ use record_lib::record::hibiki;
 use std::env::set_var;
 
 fn main() {
-    set_var("RS_NET_ARCHIVE_PATH", "./Temp");
+    const RS_NET_ARCHIVE_PATH_KEY: &str = "RS_NET_ARCHIVE_PATH";
+    set_var(RS_NET_ARCHIVE_PATH_KEY, "./Temp");
     hibiki::record();
 
     println!("{}", hibiki::format_forbidden_char("Fate/Test"));

--- a/record-lib/examples/hibiki-toybox.rs
+++ b/record-lib/examples/hibiki-toybox.rs
@@ -2,8 +2,7 @@ use record_lib::record::hibiki;
 use std::env::set_var;
 
 fn main() {
-    const RS_NET_ARCHIVE_PATH_KEY: &str = "RS_NET_ARCHIVE_PATH";
-    set_var(RS_NET_ARCHIVE_PATH_KEY, "./Temp");
+    set_var(hibiki::RS_NET_ARCHIVE_PATH_KEY, "./Temp");
     hibiki::record();
 
     println!("{}", hibiki::format_forbidden_char("Fate/Test"));


### PR DESCRIPTION
Replaces the string literal in `std::env::set_var` with a constant in `record-lib/examples/hibiki-toybox.rs` to prevent potential typos, addressing issue RS-W1015.

The file `record-lib/src/record/hibiki.rs` was reviewed but not changed. It defines a static string for the environment variable key (`RS_NET_ARCHIVE_PATH`) and uses that static string in `env::var`. This is considered good practice as it centralizes the definition of the key, reducing the risk of typos, even though the static string itself is initialized with a literal. The linter might flag the definition of the static string, but the usage is robust.

FIXES #167 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the way an environment variable key is specified by introducing a named constant, with no change to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->