### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS via unplanned process termination in library

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-26 - [Unplanned Process Termination in Library]
+**Vulnerability:** Library utility functions called `std::process::exit` on HTTP errors (403/429) and HTML parsing failures.
+**Learning:** Using `exit()` in a library is a Denial of Service (DoS) risk and poor architectural practice. It prevents the host application from handling errors gracefully and can terminate unrelated tasks (e.g., in a batch or scheduled recording).
+**Prevention:** Library functions should always return `Result` or custom error types, allowing the caller to decide on the exit strategy or recovery.

--- a/record-lib/src/utils.rs
+++ b/record-lib/src/utils.rs
@@ -175,7 +175,6 @@ pub fn http_error(status_code: u16, url: &str) -> RecordError {
 /// # Errors
 ///
 /// Returns `RecordError` if the response status indicates an error (4xx or 5xx).
-/// Note: For status codes 403 and 429, this function will exit the process with code 2.
 pub fn check_http_status(
     response: &reqwest::blocking::Response,
     url: &str,
@@ -185,17 +184,11 @@ pub fn check_http_status(
     if status.is_client_error() || status.is_server_error() {
         let status_code = status.as_u16();
 
-        // Handle specific error codes with custom exit behavior
-        match status_code {
-            403 | 429 => {
-                log::error!("HTTP {status_code} error for {url}. Access denied or rate limited.");
-                log::error!("This application will exit with code 2. Please try again later or check your access permissions.");
-                std::process::exit(2);
-            }
-            _ => {
-                return Err(http_error(status_code, url));
-            }
+        // Log specific error codes for transparency
+        if status_code == 403 || status_code == 429 {
+            log::error!("HTTP {status_code} error for {url}. Access denied or rate limited.");
         }
+        return Err(http_error(status_code, url));
     }
 
     Ok(())
@@ -215,8 +208,8 @@ pub fn html_parsing_error(url: &str, message: &str) -> RecordError {
 pub fn handle_html_parsing_error(url: &str, error: &str) -> RecordError {
     log::error!("HTML parsing failed for URL: {url}");
     log::error!("Error: {error}");
-    log::error!("This may indicate a change in the website structure. The application will exit with code 3.");
+    log::error!("This may indicate a change in the website structure.");
     log::error!("Please report this issue so the scraper can be updated.");
 
-    std::process::exit(3);
+    html_parsing_error(url, error)
 }

--- a/record-lib/tests/integration_hibiki.rs
+++ b/record-lib/tests/integration_hibiki.rs
@@ -8,7 +8,7 @@
 
 use mockito::{Mock, ServerGuard};
 use record_lib::record::hibiki_scraper::HibikiScraper;
-use record_lib::utils::{check_http_status, html_parsing_error, http_error, RecordError};
+use record_lib::utils::{check_http_status, html_parsing_error, RecordError};
 
 /// Creates a mock server that returns a specific HTTP status code
 fn create_status_mock(server: &mut ServerGuard, status_code: usize, path: &str) -> Mock {
@@ -230,17 +230,18 @@ fn test_http_status_check_with_403() {
 
     let client = reqwest::blocking::Client::new();
     let url = format!("{}/forbidden", server.url());
-    let _response = client.get(&url).send().expect("Failed to send request");
+    let response = client.get(&url).send().expect("Failed to send request");
 
-    // Note: check_http_status will call process::exit(2) for 403
-    // We can't actually test that in unit tests, but we can verify the error would be created
-    let error = http_error(403, &url);
-    match error {
-        RecordError::HttpError {
+    // check_http_status should return an error for 403 instead of exiting
+    let result = check_http_status(&response, &url);
+    assert!(result.is_err(), "Should return error for 403 status");
+
+    match result {
+        Err(RecordError::HttpError {
             status_code,
             url: error_url,
             ..
-        } => {
+        }) => {
             assert_eq!(status_code, 403);
             assert_eq!(error_url, url);
         }
@@ -255,17 +256,18 @@ fn test_http_status_check_with_429() {
 
     let client = reqwest::blocking::Client::new();
     let url = format!("{}/rate-limited", server.url());
-    let _response = client.get(&url).send().expect("Failed to send request");
+    let response = client.get(&url).send().expect("Failed to send request");
 
-    // Note: check_http_status will call process::exit(2) for 429
-    // We can't actually test that in unit tests, but we can verify the error would be created
-    let error = http_error(429, &url);
-    match error {
-        RecordError::HttpError {
+    // check_http_status should return an error for 429 instead of exiting
+    let result = check_http_status(&response, &url);
+    assert!(result.is_err(), "Should return error for 429 status");
+
+    match result {
+        Err(RecordError::HttpError {
             status_code,
             url: error_url,
             ..
-        } => {
+        }) => {
             assert_eq!(status_code, 429);
             assert_eq!(error_url, url);
         }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Library functions \`check_http_status\` and \`handle_html_parsing_error\` were calling \`std::process::exit\`.
🎯 Impact: A single HTTP error (403/429) or parsing failure for one radio program would kill the entire application, preventing other programs in a batch or scheduled run from being processed (Denial of Service).
🔧 Fix: Removed \`std::process::exit\` calls and replaced them with \`RecordError\` returns, allowing callers to handle errors gracefully.
✅ Verification: Updated \`record-lib/tests/integration_hibiki.rs\` to assert that errors are returned instead of exiting. Ran \`cargo test\` and verified all tests pass.

---
*PR created automatically by Jules for task [6174421576210497209](https://jules.google.com/task/6174421576210497209) started by @Protom512*