### PR TITLE
🛡️ Sentinel: [security improvement] Enforce HTTPS and secure error handling in Radiko service

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2026-02-16 - Library Process Exit and Insecure HTTP
+**Vulnerability:** Use of `std::process::exit` in library functions and insecure HTTP for API calls.
+**Learning:** Calling `std::process::exit` in a library is a form of local Denial of Service as it prevents the host application from handling errors gracefully (e.g., continuing a batch process). Also, legacy endpoints often still use `http` when `https` is available.
+**Prevention:** Always return `Result` from library functions. Favor `https` for all external API calls. Sanitize all variables used in URL construction, even if they seem like internal IDs.

--- a/record-lib/src/record/radiko.rs
+++ b/record-lib/src/record/radiko.rs
@@ -400,7 +400,8 @@ impl ChStreamingUrl {
     #[must_use]
     pub fn init(ch: &str) -> ChStreamingUrl {
         let client = crate::http::blocking_client();
-        let url = format!("http://radiko.jp/v2/station/stream_smh_multi/{ch}.xml");
+        let sanitized_ch = sanitize_filename(ch);
+        let url = format!("https://radiko.jp/v2/station/stream_smh_multi/{sanitized_ch}.xml");
         debug!("{:#?}", &url);
         match client.get(url).send() {
             Ok(m) => {
@@ -435,7 +436,8 @@ impl ChStreamingUrl {
 #[must_use]
 pub fn get_program_dom(ch: &str) -> Response {
     let client = crate::http::blocking_client();
-    let url = format!("http://radiko.jp/v2/api/program/station/weekly?station_id={ch}");
+    let sanitized_ch = sanitize_filename(ch);
+    let url = format!("https://radiko.jp/v2/api/program/station/weekly?station_id={sanitized_ch}");
     info!("{:#?}", &url);
     match client.get(url).send() {
         Ok(m) => m,

--- a/record-lib/src/utils.rs
+++ b/record-lib/src/utils.rs
@@ -185,17 +185,10 @@ pub fn check_http_status(
     if status.is_client_error() || status.is_server_error() {
         let status_code = status.as_u16();
 
-        // Handle specific error codes with custom exit behavior
-        match status_code {
-            403 | 429 => {
-                log::error!("HTTP {status_code} error for {url}. Access denied or rate limited.");
-                log::error!("This application will exit with code 2. Please try again later or check your access permissions.");
-                std::process::exit(2);
-            }
-            _ => {
-                return Err(http_error(status_code, url));
-            }
+        if status_code == 403 || status_code == 429 {
+            log::error!("HTTP {status_code} error for {url}. Access denied or rate limited.");
         }
+        return Err(http_error(status_code, url));
     }
 
     Ok(())
@@ -215,8 +208,8 @@ pub fn html_parsing_error(url: &str, message: &str) -> RecordError {
 pub fn handle_html_parsing_error(url: &str, error: &str) -> RecordError {
     log::error!("HTML parsing failed for URL: {url}");
     log::error!("Error: {error}");
-    log::error!("This may indicate a change in the website structure. The application will exit with code 3.");
-    log::error!("Please report this issue so the scraper can be updated.");
+    log::warn!("This may indicate a change in the website structure.");
+    log::warn!("Please report this issue so the scraper can be updated.");
 
-    std::process::exit(3);
+    html_parsing_error(url, error)
 }

--- a/record-lib/tests/integration_hibiki.rs
+++ b/record-lib/tests/integration_hibiki.rs
@@ -8,7 +8,7 @@
 
 use mockito::{Mock, ServerGuard};
 use record_lib::record::hibiki_scraper::HibikiScraper;
-use record_lib::utils::{check_http_status, html_parsing_error, http_error, RecordError};
+use record_lib::utils::{check_http_status, html_parsing_error, RecordError};
 
 /// Creates a mock server that returns a specific HTTP status code
 fn create_status_mock(server: &mut ServerGuard, status_code: usize, path: &str) -> Mock {
@@ -230,17 +230,18 @@ fn test_http_status_check_with_403() {
 
     let client = reqwest::blocking::Client::new();
     let url = format!("{}/forbidden", server.url());
-    let _response = client.get(&url).send().expect("Failed to send request");
+    let response = client.get(&url).send().expect("Failed to send request");
 
-    // Note: check_http_status will call process::exit(2) for 403
-    // We can't actually test that in unit tests, but we can verify the error would be created
-    let error = http_error(403, &url);
-    match error {
-        RecordError::HttpError {
+    // check_http_status should return an error for 403
+    let result = check_http_status(&response, &url);
+    assert!(result.is_err(), "Should return error for 403 status");
+
+    match result {
+        Err(RecordError::HttpError {
             status_code,
             url: error_url,
             ..
-        } => {
+        }) => {
             assert_eq!(status_code, 403);
             assert_eq!(error_url, url);
         }
@@ -255,17 +256,18 @@ fn test_http_status_check_with_429() {
 
     let client = reqwest::blocking::Client::new();
     let url = format!("{}/rate-limited", server.url());
-    let _response = client.get(&url).send().expect("Failed to send request");
+    let response = client.get(&url).send().expect("Failed to send request");
 
-    // Note: check_http_status will call process::exit(2) for 429
-    // We can't actually test that in unit tests, but we can verify the error would be created
-    let error = http_error(429, &url);
-    match error {
-        RecordError::HttpError {
+    // check_http_status should return an error for 429
+    let result = check_http_status(&response, &url);
+    assert!(result.is_err(), "Should return error for 429 status");
+
+    match result {
+        Err(RecordError::HttpError {
             status_code,
             url: error_url,
             ..
-        } => {
+        }) => {
             assert_eq!(status_code, 429);
             assert_eq!(error_url, url);
         }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Insecure HTTP communication and insecure process termination.
🎯 Impact: MITM attacks on Radiko API calls; local Denial of Service (DoS) of the whole application due to a single failed request.
🔧 Fix: Upgraded Radiko API endpoints to HTTPS, sanitized channel IDs using `sanitize_filename`, and replaced `std::process::exit` with proper `Result` errors in `check_http_status` and `handle_html_parsing_error`.
✅ Verification: Ran `cargo test` and `cargo clippy`. All tests passed, including updated integration tests that verify error returning instead of process exiting.

---
*PR created automatically by Jules for task [1912539534235851879](https://jules.google.com/task/1912539534235851879) started by @Protom512*