### PR TITLE
🛡️ Sentinel: Sanitize Radiko channel IDs to prevent URL injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-23 - [Radiko Channel ID Sanitization]
+**Vulnerability:** URL Injection / SSRF in Radiko API calls.
+**Learning:** Station IDs were interpolated directly into API URLs without validation. Using `sanitize_filename` is helpful but strict alphanumeric filtering is more appropriate for URL parameters to prevent injection of query parameters (using `&` or `?`) or path traversal.
+**Prevention:** Always validate or sanitize externally-sourced identifiers before using them in URL construction. Prefer strict allow-lists (like alphanumeric) for identifiers.

--- a/record-lib/src/record/radiko.rs
+++ b/record-lib/src/record/radiko.rs
@@ -399,6 +399,7 @@ impl ChStreamingUrl {
     /// A `ChStreamingUrl` struct containing streaming URL information.
     #[must_use]
     pub fn init(ch: &str) -> ChStreamingUrl {
+        let ch: String = ch.chars().filter(|c| c.is_alphanumeric()).collect();
         let client = crate::http::blocking_client();
         let url = format!("http://radiko.jp/v2/station/stream_smh_multi/{ch}.xml");
         debug!("{:#?}", &url);
@@ -434,6 +435,7 @@ impl ChStreamingUrl {
 /// A `reqwest::blocking::Response` containing the program DOM.
 #[must_use]
 pub fn get_program_dom(ch: &str) -> Response {
+    let ch: String = ch.chars().filter(|c| c.is_alphanumeric()).collect();
     let client = crate::http::blocking_client();
     let url = format!("http://radiko.jp/v2/api/program/station/weekly?station_id={ch}");
     info!("{:#?}", &url);
@@ -562,4 +564,21 @@ fn test_parse_date() {
         progdate._parse_date(),
         NaiveDate::parse_from_str("20211125", "%Y%m%d").unwrap()
     );
+}
+
+#[test]
+fn test_ch_sanitization() {
+    let malicious_ch = "QRR/../../etc/passwd";
+    let sanitized: String = malicious_ch.chars().filter(|c| c.is_alphanumeric()).collect();
+    // Alphanumeric filter removes / and .
+    assert!(!sanitized.contains('/'));
+    assert!(!sanitized.contains('.'));
+    assert_eq!(sanitized, "QRRetcpasswd");
+
+    let injection_ch = "QRR?extra=param";
+    let sanitized_injection: String = injection_ch.chars().filter(|c| c.is_alphanumeric()).collect();
+    // Alphanumeric filter removes ? and =
+    assert!(!sanitized_injection.contains('?'));
+    assert!(!sanitized_injection.contains('='));
+    assert_eq!(sanitized_injection, "QRRextraparam");
 }

--- a/record-lib/src/record/radiko.rs
+++ b/record-lib/src/record/radiko.rs
@@ -569,14 +569,20 @@ fn test_parse_date() {
 #[test]
 fn test_ch_sanitization() {
     let malicious_ch = "QRR/../../etc/passwd";
-    let sanitized: String = malicious_ch.chars().filter(|c| c.is_alphanumeric()).collect();
+    let sanitized: String = malicious_ch
+        .chars()
+        .filter(|c| c.is_alphanumeric())
+        .collect();
     // Alphanumeric filter removes / and .
     assert!(!sanitized.contains('/'));
     assert!(!sanitized.contains('.'));
     assert_eq!(sanitized, "QRRetcpasswd");
 
     let injection_ch = "QRR?extra=param";
-    let sanitized_injection: String = injection_ch.chars().filter(|c| c.is_alphanumeric()).collect();
+    let sanitized_injection: String = injection_ch
+        .chars()
+        .filter(|c| c.is_alphanumeric())
+        .collect();
     // Alphanumeric filter removes ? and =
     assert!(!sanitized_injection.contains('?'));
     assert!(!sanitized_injection.contains('='));


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Radiko station IDs were interpolated directly into API URLs without sanitization.
🎯 Impact: An attacker could potentially inject URL query parameters or perform path traversal within the target domain, leading to SSRF or unexpected API behavior.
🔧 Fix: Implemented strict alphanumeric filtering for channel IDs in `record-lib/src/record/radiko.rs`.
✅ Verification: Added a unit test `test_ch_sanitization` and ran all project tests via `cargo test`.

---
*PR created automatically by Jules for task [14389736914289311540](https://jules.google.com/task/14389736914289311540) started by @Protom512*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL injection vulnerability in Radiko API by implementing channel identifier validation to prevent malicious input in URLs.

* **Tests**
  * Added validation tests for channel identifier sanitization to ensure only safe characters are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->