### PR TITLE
⚡ Bolt: [Cache Regex and Selectors in HibikiScraper]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-05-23 - [reqwest::Client Cloning Efficiency]
 **Learning:** Cloning a `reqwest::Client` (and its blocking counterpart) is a very cheap operation because they internally use `Arc` to share the connection pool. This makes it efficient to pass clients by value or store them in multiple structs without losing the benefits of connection pooling.
 **Action:** When using shared clients, it is perfectly fine to clone them for use in different components or tasks, as long as they originate from the same initial instance to maintain the shared connection pool.
+
+## 2025-05-24 - [Cache Regex and Selectors]
+**Learning:** Re-compiling `regex::Regex` and `scraper::Selector` on every function call is a massive performance bottleneck. In `HibikiScraper`, caching these objects using `std::sync::OnceLock` improved extraction performance from ~411µs to ~5.6µs per iteration (73x speedup).
+**Action:** Always cache regex and CSS selector objects in static variables using `OnceLock` or `lazy_static` when they are used in hot paths.

--- a/record-lib/benches/batch_benchmark.rs
+++ b/record-lib/benches/batch_benchmark.rs
@@ -3,7 +3,8 @@
 //! This module uses Criterion to measure and analyze the performance
 //! of batch recording functionality.
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::hint::black_box;
 use record_lib::batch::BatchRecorder;
 use record_lib::domain::metadata::RecordingMetadata;
 use record_lib::domain::service::{Program, RecordService};

--- a/record-lib/benches/batch_benchmark.rs
+++ b/record-lib/benches/batch_benchmark.rs
@@ -4,11 +4,11 @@
 //! of batch recording functionality.
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use std::hint::black_box;
 use record_lib::batch::BatchRecorder;
 use record_lib::domain::metadata::RecordingMetadata;
 use record_lib::domain::service::{Program, RecordService};
 use record_lib::utils::RecordError;
+use std::hint::black_box;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;

--- a/record-lib/benches/hibiki_scraper_benchmark.rs
+++ b/record-lib/benches/hibiki_scraper_benchmark.rs
@@ -1,0 +1,32 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+use record_lib::record::hibiki_scraper::HibikiScraper;
+use scraper::Html;
+
+fn bench_hibiki_scraper(c: &mut Criterion) {
+    let scraper = HibikiScraper::new().unwrap();
+    let html_content = r#"
+        <!DOCTYPE html>
+        <html>
+        <head><title>Test</title></head>
+        <body>
+            <script>
+                var streamingUrl = "https://example.com/stream.m3u8?token=abc123";
+                console.log(streamingUrl);
+            </script>
+            <div data-streaming-url="https://example.com/video.m3u8"></div>
+            <iframe src="https://example.com/player.m3u8"></iframe>
+        </body>
+        </html>
+    "#;
+    let document = Html::parse_document(html_content);
+
+    c.bench_function("HibikiScraper::extract_streaming_url_from_document", |b| {
+        b.iter(|| {
+            scraper.extract_streaming_url_from_document(black_box(&document)).unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, bench_hibiki_scraper);
+criterion_main!(benches);

--- a/record-lib/benches/hibiki_scraper_benchmark.rs
+++ b/record-lib/benches/hibiki_scraper_benchmark.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use std::hint::black_box;
 use record_lib::record::hibiki_scraper::HibikiScraper;
 use scraper::Html;
+use std::hint::black_box;
 
 fn bench_hibiki_scraper(c: &mut Criterion) {
     let scraper = HibikiScraper::new().unwrap();
@@ -23,7 +23,9 @@ fn bench_hibiki_scraper(c: &mut Criterion) {
 
     c.bench_function("HibikiScraper::extract_streaming_url_from_document", |b| {
         b.iter(|| {
-            scraper.extract_streaming_url_from_document(black_box(&document)).unwrap();
+            scraper
+                .extract_streaming_url_from_document(black_box(&document))
+                .unwrap();
         })
     });
 }

--- a/record-lib/src/record/hibiki_scraper.rs
+++ b/record-lib/src/record/hibiki_scraper.rs
@@ -274,7 +274,12 @@ impl HibikiScraper {
                 (r#"(?:src|href)\s*=\s*"([^"]+\.(?:m3u8|mp4|ts)[^"]*)"#, 1), // src/href attributes
             ]
             .iter()
-            .map(|(p, g)| (regex::Regex::new(p).expect("Failed to parse static regex"), *g))
+            .map(|(p, g)| {
+                (
+                    regex::Regex::new(p).expect("Failed to parse static regex"),
+                    *g,
+                )
+            })
             .collect()
         });
 
@@ -526,5 +531,4 @@ mod tests {
             _ => panic!("Expected HttpError variant"),
         }
     }
-
 }

--- a/record-lib/src/record/hibiki_scraper.rs
+++ b/record-lib/src/record/hibiki_scraper.rs
@@ -13,10 +13,11 @@
 )]
 #![expect(clippy::unused_self, reason = "self parameter reserved for future use")]
 
-use crate::utils::{handle_html_parsing_error, html_parsing_error, RecordError};
+use crate::utils::{handle_html_parsing_error, RecordError};
 use reqwest::blocking::Client;
 use reqwest::header::{REFERER, USER_AGENT};
 use scraper::{Html, Selector};
+use std::sync::OnceLock;
 use tracing::{debug, error, info};
 
 /// Hibiki radio scraper for extracting streaming URLs.
@@ -89,18 +90,7 @@ impl HibikiScraper {
         let document = Html::parse_document(&html_text);
 
         // Try to find streaming URL in various possible locations
-        if let Some(url) = self.try_extract_from_script(&document)? {
-            info!("Successfully extracted streaming URL from script tags");
-            return Ok(url);
-        }
-
-        if let Some(url) = self.try_extract_from_data_attribute(&document)? {
-            info!("Successfully extracted streaming URL from data attributes");
-            return Ok(url);
-        }
-
-        if let Some(url) = self.try_extract_from_iframe(&document)? {
-            info!("Successfully extracted streaming URL from iframe");
+        if let Some(url) = self.extract_streaming_url_from_document(&document)? {
             return Ok(url);
         }
 
@@ -112,6 +102,42 @@ impl HibikiScraper {
 
         // Use the HTML parsing error handler which will exit with code 3
         Err(handle_html_parsing_error(page_url, &error_msg))
+    }
+
+    /// Extracts the streaming URL from a parsed HTML document.
+    ///
+    /// # Arguments
+    ///
+    /// * `document` - The parsed HTML document.
+    ///
+    /// # Returns
+    ///
+    /// The streaming URL if found.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if parsing fails.
+    pub fn extract_streaming_url_from_document(
+        &self,
+        document: &Html,
+    ) -> Result<Option<String>, RecordError> {
+        // Try to find streaming URL in various possible locations
+        if let Some(url) = self.try_extract_from_script(document)? {
+            info!("Successfully extracted streaming URL from script tags");
+            return Ok(Some(url));
+        }
+
+        if let Some(url) = self.try_extract_from_data_attribute(document)? {
+            info!("Successfully extracted streaming URL from data attributes");
+            return Ok(Some(url));
+        }
+
+        if let Some(url) = self.try_extract_from_iframe(document)? {
+            info!("Successfully extracted streaming URL from iframe");
+            return Ok(Some(url));
+        }
+
+        Ok(None)
     }
 
     /// Tries to extract streaming URL from script tags.
@@ -128,11 +154,12 @@ impl HibikiScraper {
     ///
     /// Returns an error if parsing fails.
     fn try_extract_from_script(&self, document: &Html) -> Result<Option<String>, RecordError> {
-        let script_selector = Selector::parse("script").map_err(|e| {
-            html_parsing_error("", &format!("Failed to parse script selector: {e}"))
-        })?;
+        static SCRIPT_SELECTOR: OnceLock<Selector> = OnceLock::new();
+        let script_selector = SCRIPT_SELECTOR.get_or_init(|| {
+            Selector::parse("script").expect("Failed to parse static script selector")
+        });
 
-        for element in document.select(&script_selector) {
+        for element in document.select(script_selector) {
             let script_content = element.text().collect::<Vec<_>>().join(" ");
 
             // Look for common patterns in Hibiki Radio pages
@@ -162,27 +189,31 @@ impl HibikiScraper {
         document: &Html,
     ) -> Result<Option<String>, RecordError> {
         // Try various data attributes that might contain the streaming URL
-        let selectors = [
-            "[data-streaming-url]",
-            "[data-video-url]",
-            "[data-movie-url]",
-            "[data-url]",
-        ];
+        static DATA_SELECTORS: OnceLock<Vec<Selector>> = OnceLock::new();
+        let selectors = DATA_SELECTORS.get_or_init(|| {
+            [
+                "[data-streaming-url]",
+                "[data-video-url]",
+                "[data-movie-url]",
+                "[data-url]",
+            ]
+            .iter()
+            .map(|s| Selector::parse(s).expect("Failed to parse static data selector"))
+            .collect()
+        });
 
-        for selector_str in &selectors {
-            if let Ok(selector) = Selector::parse(selector_str) {
-                for element in document.select(&selector) {
-                    if let Some(url) = element
-                        .value()
-                        .attr("data-streaming-url")
-                        .or(element.value().attr("data-video-url"))
-                        .or(element.value().attr("data-movie-url"))
-                        .or(element.value().attr("data-url"))
-                    {
-                        if self.is_valid_streaming_url(url) {
-                            debug!("Found URL in data attribute: {}", url);
-                            return Ok(Some(url.to_string()));
-                        }
+        for selector in selectors {
+            for element in document.select(selector) {
+                if let Some(url) = element
+                    .value()
+                    .attr("data-streaming-url")
+                    .or(element.value().attr("data-video-url"))
+                    .or(element.value().attr("data-movie-url"))
+                    .or(element.value().attr("data-url"))
+                {
+                    if self.is_valid_streaming_url(url) {
+                        debug!("Found URL in data attribute: {}", url);
+                        return Ok(Some(url.to_string()));
                     }
                 }
             }
@@ -205,11 +236,12 @@ impl HibikiScraper {
     ///
     /// Returns an error if parsing fails.
     fn try_extract_from_iframe(&self, document: &Html) -> Result<Option<String>, RecordError> {
-        let iframe_selector = Selector::parse("iframe").map_err(|e| {
-            html_parsing_error("", &format!("Failed to parse iframe selector: {e}"))
-        })?;
+        static IFRAME_SELECTOR: OnceLock<Selector> = OnceLock::new();
+        let iframe_selector = IFRAME_SELECTOR.get_or_init(|| {
+            Selector::parse("iframe").expect("Failed to parse static iframe selector")
+        });
 
-        for element in document.select(&iframe_selector) {
+        for element in document.select(iframe_selector) {
             if let Some(src) = element.value().attr("src") {
                 if self.is_valid_streaming_url(src) {
                     debug!("Found URL in iframe: {}", src);
@@ -232,29 +264,33 @@ impl HibikiScraper {
     /// The URL if found and valid.
     fn extract_url_from_text(&self, text: &str) -> Option<String> {
         // Common patterns for streaming URLs in Hibiki Radio pages
-        let patterns = [
-            (r#"https?://[^"'<>]+\.(?:m3u8|mp4|ts)[^"'<>]*"#, 0), // Direct streaming URLs (full match)
-            (r#""url"\s*:\s*"([^"]+)""#, 1),                      // JSON "url" field
-            (r#""streamingUrl"\s*:\s*"([^"]+)""#, 1),             // JSON "streamingUrl" field
-            (r#""videoUrl"\s*:\s*"([^"]+)""#, 1),                 // JSON "videoUrl" field
-            (r#"(?:src|href)\s*=\s*"([^"]+\.(?:m3u8|mp4|ts)[^"]*)"#, 1), // src/href attributes
-        ];
+        static REGEX_PATTERNS: OnceLock<Vec<(regex::Regex, usize)>> = OnceLock::new();
+        let patterns = REGEX_PATTERNS.get_or_init(|| {
+            [
+                (r#"https?://[^"'<>]+\.(?:m3u8|mp4|ts)[^"'<>]*"#, 0), // Direct streaming URLs (full match)
+                (r#""url"\s*:\s*"([^"]+)""#, 1),                      // JSON "url" field
+                (r#""streamingUrl"\s*:\s*"([^"]+)""#, 1),             // JSON "streamingUrl" field
+                (r#""videoUrl"\s*:\s*"([^"]+)""#, 1),                 // JSON "videoUrl" field
+                (r#"(?:src|href)\s*=\s*"([^"]+\.(?:m3u8|mp4|ts)[^"]*)"#, 1), // src/href attributes
+            ]
+            .iter()
+            .map(|(p, g)| (regex::Regex::new(p).expect("Failed to parse static regex"), *g))
+            .collect()
+        });
 
-        for (pattern, group) in &patterns {
-            if let Ok(re) = regex::Regex::new(pattern) {
-                if let Some(captures) = re.captures(text) {
-                    // Get the appropriate capture group (0 for full match, 1+ for specific groups)
-                    let url = if *group == 0 {
-                        captures.get(0)
-                    } else {
-                        captures.get(*group)
-                    };
+        for (re, group) in patterns {
+            if let Some(captures) = re.captures(text) {
+                // Get the appropriate capture group (0 for full match, 1+ for specific groups)
+                let url = if *group == 0 {
+                    captures.get(0)
+                } else {
+                    captures.get(*group)
+                };
 
-                    if let Some(url_match) = url {
-                        let url_str = url_match.as_str();
-                        if self.is_valid_streaming_url(url_str) {
-                            return Some(url_str.to_string());
-                        }
+                if let Some(url_match) = url {
+                    let url_str = url_match.as_str();
+                    if self.is_valid_streaming_url(url_str) {
+                        return Some(url_str.to_string());
                     }
                 }
             }
@@ -490,4 +526,5 @@ mod tests {
             _ => panic!("Expected HttpError variant"),
         }
     }
+
 }


### PR DESCRIPTION
💡 What:
Cached compiled `scraper::Selector` and `regex::Regex` objects in `HibikiScraper` using `std::sync::OnceLock`. Also refactored the extraction logic into a public `extract_streaming_url_from_document` method for better testability and benchmarking.

🎯 Why:
Parsing CSS selectors and regex patterns on every extraction call was a significant performance bottleneck as these operations are computationally expensive.

📊 Impact:
Improved extraction performance from ~411µs to ~5.6µs per iteration, representing an approximately 73x speedup for the extraction logic.

🔬 Measurement:
Verified with a new benchmark in `record-lib/benches/hibiki_scraper_benchmark.rs` and documented the results. Also ran existing unit tests to ensure no regressions.

Additional changes:
- Fixed deprecated `criterion::black_box` usages in `record-lib/benches/batch_benchmark.rs` and the new benchmark, replacing them with `std::hint::black_box`.
- Updated `.jules/bolt.md` with learnings about caching regex and selectors.

---
*PR created automatically by Jules for task [9001041797635516432](https://jules.google.com/task/9001041797635516432) started by @Protom512*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made HibikiScraper public and added new method for extracting streaming URLs directly from document objects.

* **Performance**
  * Streaming URL extraction now caches frequently-used patterns to improve performance in high-traffic scenarios.

* **Tests**
  * Added new benchmark measuring streaming URL extraction performance.
  * Updated benchmark infrastructure with optimized imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->