### PR TITLE
🛡️ Sentinel: [security improvement] Upgrade Radiko API to HTTPS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** URL Injection / SSRF in Radiko API calls.
 **Learning:** Station IDs were interpolated directly into API URLs without validation. Using `sanitize_filename` is helpful but strict alphanumeric filtering is more appropriate for URL parameters to prevent injection of query parameters (using `&` or `?`) or path traversal.
 **Prevention:** Always validate or sanitize externally-sourced identifiers before using them in URL construction. Prefer strict allow-lists (like alphanumeric) for identifiers.
+
+## 2026-03-02 - [Radiko API HTTPS Upgrade]
+**Vulnerability:** Eavesdropping / MITM on Radiko API communication.
+**Learning:** Some API endpoints were still using `http` instead of `https`, potentially exposing station XML data and program schedules to eavesdropping or tampering.
+**Prevention:** Always use `https` for API communication to ensure data is encrypted in transit and the server's identity is verified.

--- a/record-lib/src/record/radiko.rs
+++ b/record-lib/src/record/radiko.rs
@@ -401,7 +401,7 @@ impl ChStreamingUrl {
     pub fn init(ch: &str) -> ChStreamingUrl {
         let ch: String = ch.chars().filter(|c| c.is_alphanumeric()).collect();
         let client = crate::http::blocking_client();
-        let url = format!("http://radiko.jp/v2/station/stream_smh_multi/{ch}.xml");
+        let url = format!("https://radiko.jp/v2/station/stream_smh_multi/{ch}.xml");
         debug!("{:#?}", &url);
         match client.get(url).send() {
             Ok(m) => {
@@ -437,7 +437,7 @@ impl ChStreamingUrl {
 pub fn get_program_dom(ch: &str) -> Response {
     let ch: String = ch.chars().filter(|c| c.is_alphanumeric()).collect();
     let client = crate::http::blocking_client();
-    let url = format!("http://radiko.jp/v2/api/program/station/weekly?station_id={ch}");
+    let url = format!("https://radiko.jp/v2/api/program/station/weekly?station_id={ch}");
     info!("{:#?}", &url);
     match client.get(url).send() {
         Ok(m) => m,


### PR DESCRIPTION
🚨 Severity: LOW/MEDIUM
💡 Vulnerability: Use of insecure HTTP for Radiko API communication.
🎯 Impact: Potential for eavesdropping or man-in-the-middle attacks on station and program data during transmission.
🔧 Fix: Upgraded Radiko API endpoints in `record-lib/src/record/radiko.rs` to use `https://` instead of `http://`.
✅ Verification: Ran `cargo test --package record-lib --lib record::radiko` and full workspace `cargo test`. All tests passed successfully. Verified that `radiko.jp` supports HTTPS on these endpoints using `curl`.

---
*PR created automatically by Jules for task [17765049580658571643](https://jules.google.com/task/17765049580658571643) started by @Protom512*