### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in recording output paths

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** URL Injection / SSRF in Radiko API calls.
 **Learning:** Station IDs were interpolated directly into API URLs without validation. Using `sanitize_filename` is helpful but strict alphanumeric filtering is more appropriate for URL parameters to prevent injection of query parameters (using `&` or `?`) or path traversal.
 **Prevention:** Always validate or sanitize externally-sourced identifiers before using them in URL construction. Prefer strict allow-lists (like alphanumeric) for identifiers.
+
+## 2026-02-24 - [Path Traversal in Recording Output Paths]
+**Vulnerability:** Path Traversal via user-provided `output_path`.
+**Learning:** Simply using `Path::file_name()` to mitigate path traversal is too restrictive as it prevents users from using legitimate subdirectories. A better approach is to iterate through `Path::components()` and only allow `Normal` components, which naturally strips `..`, root, and prefixes.
+**Prevention:** When processing user-provided paths that should stay within a specific directory, reconstruct the path component-by-component, allowing only `Normal` components and sanitizing each one.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,7 @@ dependencies = [
  "chrono",
  "clap",
  "record-lib",
+ "tempdir",
  "tokio",
  "tokio-cron-scheduler",
  "toml",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -15,4 +15,5 @@ toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-
+[dev-dependencies]
+tempdir = "0.3"

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -304,7 +304,11 @@ mod tests {
         let file_path = dir.path().join("test_list.txt");
         let mut file = std::fs::File::create(&file_path).unwrap();
         writeln!(file, "Malicious|http://example.com/stream|../../etc/passwd").unwrap();
-        writeln!(file, "Windows|http://example.com/stream|C:\\Windows\\System32\\drivers\\etc\\hosts").unwrap();
+        writeln!(
+            file,
+            "Windows|http://example.com/stream|C:\\Windows\\System32\\drivers\\etc\\hosts"
+        )
+        .unwrap();
         writeln!(file, "Normal|http://example.com/stream|program.mp4").unwrap();
 
         let programs = parse_program_list(&file_path).unwrap();

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -167,7 +167,21 @@ async fn run_cron_scheduling(config_path: PathBuf) -> Result<()> {
         .context("Failed to create cron manager")?;
 
     // Add schedules
-    for schedule in cron_config.schedules {
+    for mut schedule in cron_config.schedules {
+        // Sanitize output_path to prevent path traversal
+        let mut sanitized_path = PathBuf::new();
+        for component in schedule.output_path.components() {
+            if let std::path::Component::Normal(c) = component {
+                if let Some(s) = c.to_str() {
+                    sanitized_path.push(record_lib::utils::sanitize_filename(s));
+                }
+            }
+        }
+        if sanitized_path.as_os_str().is_empty() {
+            sanitized_path.push("output.mp4");
+        }
+        schedule.output_path = sanitized_path;
+
         cron_manager
             .add_schedule(schedule)
             .await
@@ -230,7 +244,24 @@ fn parse_program_list(path: &PathBuf) -> Result<Vec<Program>> {
 
         let title = parts[0].to_string();
         let url = parts[1].to_string();
-        let output_path = PathBuf::from(parts[2]);
+
+        // Extract components and sanitize each to prevent path traversal
+        // Only allow relative paths without '..' to ensure recordings stay within the intended directory
+        let raw_output_path = std::path::Path::new(parts[2]);
+        let mut sanitized_path = PathBuf::new();
+        for component in raw_output_path.components() {
+            if let std::path::Component::Normal(c) = component {
+                if let Some(s) = c.to_str() {
+                    sanitized_path.push(record_lib::utils::sanitize_filename(s));
+                }
+            }
+        }
+
+        // Default filename if path was empty after sanitization
+        if sanitized_path.as_os_str().is_empty() {
+            sanitized_path.push("output.mp4");
+        }
+        let output_path = sanitized_path;
 
         programs.push(Program {
             title,
@@ -259,4 +290,38 @@ fn load_cron_config(path: &PathBuf) -> Result<record_lib::config::CronConfig> {
         .with_context(|| format!("Failed to parse cron config: {}", path.display()))?;
 
     Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempdir::TempDir;
+
+    #[test]
+    fn test_parse_program_list_sanitization() {
+        let dir = TempDir::new("test").unwrap();
+        let file_path = dir.path().join("test_list.txt");
+        let mut file = std::fs::File::create(&file_path).unwrap();
+        writeln!(file, "Malicious|http://example.com/stream|../../etc/passwd").unwrap();
+        writeln!(file, "Windows|http://example.com/stream|C:\\Windows\\System32\\drivers\\etc\\hosts").unwrap();
+        writeln!(file, "Normal|http://example.com/stream|program.mp4").unwrap();
+
+        let programs = parse_program_list(&file_path).unwrap();
+
+        assert_eq!(programs.len(), 3);
+
+        // ../../etc/passwd should become etc/passwd (it strips ../../)
+        assert_eq!(programs[0].output_path.to_str().unwrap(), "etc/passwd");
+
+        // C:\Windows\System32\drivers\etc\hosts should be sanitized
+        // On Unix, \ is just a character, so it's a single component
+        let hosts_path = programs[1].output_path.to_str().unwrap();
+        assert!(!hosts_path.contains("\\"));
+        assert!(!hosts_path.contains("/"));
+        assert!(hosts_path.contains("hosts"));
+
+        // normal filename should remain unchanged
+        assert_eq!(programs[2].output_path.to_str().unwrap(), "program.mp4");
+    }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path Traversal
🎯 Impact: An attacker could potentially write recordings to sensitive locations on the system, such as overwriting configuration files or adding SSH keys, if they could control the program list or cron config.
🔧 Fix: Reconstruct output paths using only `Normal` components and apply filename sanitization to each.
✅ Verification: Added unit tests in `app/src/main.rs` and ran `cargo test --bin rs-net-radio`.

This PR fixes a high-priority path traversal vulnerability in the recording output path handling. It ensures that user-provided paths cannot escape the intended archive directory by stripping any parent directory or root components and sanitizing each remaining component. Comprehensive unit tests have been added to verify the fix across various scenarios including malicious paths.

---
*PR created automatically by Jules for task [18284141944848439423](https://jules.google.com/task/18284141944848439423) started by @Protom512*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Implemented path sanitization for user-provided output paths to prevent invalid path components from being used.

* **Tests**
  * Added comprehensive tests validating path sanitization behavior across various input formats.

* **Documentation**
  * Updated security guidance on safe path handling practices.

* **Chores**
  * Added development dependency to support testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->