### PR TITLE
🛡️ Sentinel: Remove uncontrolled process exits in library code

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,4 +6,9 @@
 ## 2026-03-16 - [Output Path Traversal in Batch/Cron]
 **Vulnerability:** Path Traversal in program list and cron configuration.
 **Learning:** User-provided `output_path` was accepted as-is from configuration files and used to construct recording paths. This allowed using `../` to traverse and potentially overwrite system files.
-**Prevention:** Never trust paths from external input. Use `Path::file_name()` to extract only the intended filename and apply sanitization (like `sanitize_filename`) before prepending the safe base directory.
+**Prevention:** Never trust paths from external input. Use `Path::file_name()` to extract only the filename component and apply sanitization (like `sanitize_filename`) before prepending the safe base directory.
+
+## 2026-03-24 - [Uncontrolled Process Exit in Library]
+**Vulnerability:** Uncontrolled process termination in library code (Availability/DoS).
+**Learning:** Library utility functions (`check_http_status`, `handle_html_parsing_error`) utilized `std::process::exit`. This prevented consuming applications from handling errors (like 429 Rate Limiting) gracefully and allowed remote servers to terminate the entire application process via specific HTTP responses.
+**Prevention:** Library code must NEVER call `std::process::exit`. Always propagate errors using `Result` or `RecordError` to allow the calling application to determine the appropriate failure strategy (e.g., retry, log, or terminate).

--- a/record-lib/src/utils.rs
+++ b/record-lib/src/utils.rs
@@ -175,7 +175,6 @@ pub fn http_error(status_code: u16, url: &str) -> RecordError {
 /// # Errors
 ///
 /// Returns `RecordError` if the response status indicates an error (4xx or 5xx).
-/// Note: For status codes 403 and 429, this function will exit the process with code 2.
 pub fn check_http_status(
     response: &reqwest::blocking::Response,
     url: &str,
@@ -184,18 +183,7 @@ pub fn check_http_status(
 
     if status.is_client_error() || status.is_server_error() {
         let status_code = status.as_u16();
-
-        // Handle specific error codes with custom exit behavior
-        match status_code {
-            403 | 429 => {
-                log::error!("HTTP {status_code} error for {url}. Access denied or rate limited.");
-                log::error!("This application will exit with code 2. Please try again later or check your access permissions.");
-                std::process::exit(2);
-            }
-            _ => {
-                return Err(http_error(status_code, url));
-            }
-        }
+        return Err(http_error(status_code, url));
     }
 
     Ok(())
@@ -215,8 +203,7 @@ pub fn html_parsing_error(url: &str, message: &str) -> RecordError {
 pub fn handle_html_parsing_error(url: &str, error: &str) -> RecordError {
     log::error!("HTML parsing failed for URL: {url}");
     log::error!("Error: {error}");
-    log::error!("This may indicate a change in the website structure. The application will exit with code 3.");
-    log::error!("Please report this issue so the scraper can be updated.");
+    log::warn!("This may indicate a change in the website structure. Please report this issue so the scraper can be updated.");
 
-    std::process::exit(3);
+    html_parsing_error(url, error)
 }

--- a/record-lib/tests/integration_hibiki.rs
+++ b/record-lib/tests/integration_hibiki.rs
@@ -8,7 +8,7 @@
 
 use mockito::{Mock, ServerGuard};
 use record_lib::record::hibiki_scraper::HibikiScraper;
-use record_lib::utils::{check_http_status, html_parsing_error, http_error, RecordError};
+use record_lib::utils::{check_http_status, html_parsing_error, RecordError};
 
 /// Creates a mock server that returns a specific HTTP status code
 fn create_status_mock(server: &mut ServerGuard, status_code: usize, path: &str) -> Mock {
@@ -230,17 +230,18 @@ fn test_http_status_check_with_403() {
 
     let client = reqwest::blocking::Client::new();
     let url = format!("{}/forbidden", server.url());
-    let _response = client.get(&url).send().expect("Failed to send request");
+    let response = client.get(&url).send().expect("Failed to send request");
 
-    // Note: check_http_status will call process::exit(2) for 403
-    // We can't actually test that in unit tests, but we can verify the error would be created
-    let error = http_error(403, &url);
-    match error {
-        RecordError::HttpError {
+    // check_http_status should now return Err instead of exiting
+    let result = check_http_status(&response, &url);
+    assert!(result.is_err(), "Should return error for 403 status");
+
+    match result {
+        Err(RecordError::HttpError {
             status_code,
             url: error_url,
             ..
-        } => {
+        }) => {
             assert_eq!(status_code, 403);
             assert_eq!(error_url, url);
         }
@@ -255,17 +256,18 @@ fn test_http_status_check_with_429() {
 
     let client = reqwest::blocking::Client::new();
     let url = format!("{}/rate-limited", server.url());
-    let _response = client.get(&url).send().expect("Failed to send request");
+    let response = client.get(&url).send().expect("Failed to send request");
 
-    // Note: check_http_status will call process::exit(2) for 429
-    // We can't actually test that in unit tests, but we can verify the error would be created
-    let error = http_error(429, &url);
-    match error {
-        RecordError::HttpError {
+    // check_http_status should now return Err instead of exiting
+    let result = check_http_status(&response, &url);
+    assert!(result.is_err(), "Should return error for 429 status");
+
+    match result {
+        Err(RecordError::HttpError {
             status_code,
             url: error_url,
             ..
-        } => {
+        }) => {
             assert_eq!(status_code, 429);
             assert_eq!(error_url, url);
         }


### PR DESCRIPTION
### 🚨 Severity: MEDIUM
### 💡 Vulnerability: Uncontrolled process termination in library code (Availability/DoS).
### 🎯 Impact: 
Consuming applications were unable to handle errors gracefully (e.g., implementing retries for rate limiting). Remote servers could trigger a complete application shutdown by returning specific HTTP status codes (403/429) or unexpected HTML structures.
### 🔧 Fix: 
Replaced `std::process::exit` calls in `record-lib/src/utils.rs` with `RecordError` returns, ensuring that error handling logic is delegated to the calling application.
### ✅ Verification: 
Updated `record-lib/tests/integration_hibiki.rs` to explicitly verify that `check_http_status` returns a `Result::Err` for 403 and 429 status codes. Ran `cargo test` and `cargo clippy` to ensure correctness and lint compliance.

---
*PR created automatically by Jules for task [16441950106884303300](https://jules.google.com/task/16441950106884303300) started by @Protom512*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unexpected process termination triggered by certain HTTP errors and parsing failures
  * Error handling now properly propagates errors, enabling applications to implement custom handling strategies such as retry logic or custom logging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->