### PR TITLE
🛡️ Sentinel: [security improvement] Remove library-induced process termination

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Path Traversal in program list and cron configuration.
 **Learning:** User-provided `output_path` was accepted as-is from configuration files and used to construct recording paths. This allowed using `../` to traverse and potentially overwrite system files.
 **Prevention:** Never trust paths from external input. Use `Path::file_name()` to extract only the intended filename and apply sanitization (like `sanitize_filename`) before prepending the safe base directory.
+
+## 2026-04-10 - [Library-Induced Denial of Service (DoS)]
+**Vulnerability:** Library functions calling `std::process::exit` based on external server responses.
+**Learning:** Functions in `record-lib` would terminate the entire host process when encountering HTTP 403/429 or HTML parsing errors. This allowed external radio services to effectively "shut down" the recording application by returning specific status codes, creating a self-induced DoS vulnerability and making the application unrecoverable during batch processing.
+**Prevention:** Library code must NEVER terminate the host process. Always propagate errors using `Result` or custom error types, allowing the calling application to decide how to handle failures (e.g., skip a single program in a batch instead of crashing the entire run).

--- a/record-lib/src/utils.rs
+++ b/record-lib/src/utils.rs
@@ -175,7 +175,6 @@ pub fn http_error(status_code: u16, url: &str) -> RecordError {
 /// # Errors
 ///
 /// Returns `RecordError` if the response status indicates an error (4xx or 5xx).
-/// Note: For status codes 403 and 429, this function will exit the process with code 2.
 pub fn check_http_status(
     response: &reqwest::blocking::Response,
     url: &str,
@@ -184,18 +183,7 @@ pub fn check_http_status(
 
     if status.is_client_error() || status.is_server_error() {
         let status_code = status.as_u16();
-
-        // Handle specific error codes with custom exit behavior
-        match status_code {
-            403 | 429 => {
-                log::error!("HTTP {status_code} error for {url}. Access denied or rate limited.");
-                log::error!("This application will exit with code 2. Please try again later or check your access permissions.");
-                std::process::exit(2);
-            }
-            _ => {
-                return Err(http_error(status_code, url));
-            }
-        }
+        return Err(http_error(status_code, url));
     }
 
     Ok(())
@@ -215,8 +203,8 @@ pub fn html_parsing_error(url: &str, message: &str) -> RecordError {
 pub fn handle_html_parsing_error(url: &str, error: &str) -> RecordError {
     log::error!("HTML parsing failed for URL: {url}");
     log::error!("Error: {error}");
-    log::error!("This may indicate a change in the website structure. The application will exit with code 3.");
+    log::error!("This may indicate a change in the website structure.");
     log::error!("Please report this issue so the scraper can be updated.");
 
-    std::process::exit(3);
+    html_parsing_error(url, error)
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Library-induced Denial of Service (DoS) via `std::process::exit` calls in `record-lib`.
🎯 Impact: External radio services could trigger an immediate application shutdown by returning 403/429 status codes or malformed HTML, preventing graceful error handling or completion of other tasks in a batch.
🔧 Fix: Replaced `std::process::exit` calls with `RecordError` returns in `check_http_status` and `handle_html_parsing_error`, enabling callers to manage failures.
✅ Verification: Ran `cargo test -p record-lib` and verified that integration tests for 403/429 errors now pass by catching errors instead of crashing.

---
*PR created automatically by Jules for task [1580682573116977544](https://jules.google.com/task/1580682573116977544) started by @Protom512*