### PR TITLE
Phase 1 安全修正: ライブラリ process::exit 除去・ffmpeg kill・メモリ会計修正 (F31/F22/F14/F23)

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -342,9 +342,11 @@ mod tests {
         let programs = parse_program_list(&path, Some(&base_dir)).unwrap();
 
         assert_eq!(programs.len(), 1);
+        // Compare as paths (not strings) so this is correct on both Unix and
+        // Windows path separators.
         assert_eq!(
-            programs[0].output_path.to_str().unwrap(),
-            "/trusted/recordings/passwd"
+            programs[0].output_path,
+            PathBuf::from("/trusted/recordings").join("passwd")
         );
 
         std::fs::remove_file(path).unwrap();

--- a/record-lib/benches/batch_benchmark.rs
+++ b/record-lib/benches/batch_benchmark.rs
@@ -3,7 +3,8 @@
 //! This module uses Criterion to measure and analyze the performance
 //! of batch recording functionality.
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use std::hint::black_box;
 use record_lib::batch::BatchRecorder;
 use record_lib::domain::metadata::RecordingMetadata;
 use record_lib::domain::service::{Program, RecordService};

--- a/record-lib/benches/batch_benchmark.rs
+++ b/record-lib/benches/batch_benchmark.rs
@@ -4,11 +4,11 @@
 //! of batch recording functionality.
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use std::hint::black_box;
 use record_lib::batch::BatchRecorder;
 use record_lib::domain::metadata::RecordingMetadata;
 use record_lib::domain::service::{Program, RecordService};
 use record_lib::utils::RecordError;
+use std::hint::black_box;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;

--- a/record-lib/examples/hibiki-toybox.rs
+++ b/record-lib/examples/hibiki-toybox.rs
@@ -12,8 +12,11 @@ async fn main() {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
-    // 3. 並列処理で録画
-    hibiki::record_parallel().await;
+    // 3. 並列処理で録画（エラー時はアプリ境界で終了コードを決定）
+    if let Err(e) = hibiki::record_parallel().await {
+        tracing::error!("hibiki recording failed: {e}");
+        std::process::exit(1);
+    }
 
     tracing::info!("Finished hibiki-toybox recording example");
 }

--- a/record-lib/src/common.rs
+++ b/record-lib/src/common.rs
@@ -2,8 +2,24 @@ use crate::utils::RecordError;
 use log::{debug, error, info};
 use std::process::{Command, ExitStatus};
 use std::time::Duration;
+use tokio::io::AsyncReadExt;
 use tokio::process::Command as TokioCommand;
 use tokio::time::timeout;
+
+/// Reads an optional child pipe to end, returning an empty buffer when absent.
+///
+/// Used to drain `stdout`/`stderr` independently of `Child` ownership so the
+/// child process can still be killed/reaped when a timeout fires.
+async fn read_pipe_to_vec<R>(pipe: Option<R>) -> Vec<u8>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut buf = Vec::new();
+    if let Some(mut p) = pipe {
+        let _ = p.read_to_end(&mut buf).await;
+    }
+    buf
+}
 
 /// 外部プロセスの実行結果を保持する構造体
 pub struct ProcessResult {
@@ -25,33 +41,49 @@ pub async fn execute_command(
 ) -> Result<ProcessResult, RecordError> {
     info!("Executing command: {} {}", cmd_name, args.join(" "));
 
-    let child = TokioCommand::new(cmd_name)
+    // `kill_on_drop(true)` is the safety net: if this future is ever dropped
+    // (timeout, cancellation, or panic) the OS process is killed instead of
+    // being orphaned. We additionally reap it explicitly on timeout below so
+    // no zombie remains.
+    let mut child = TokioCommand::new(cmd_name)
         .args(args)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
         .spawn()
         .map_err(RecordError::Io)?;
 
-    let result = if let Some(d) = timeout_duration {
-        match timeout(d, child.wait_with_output()).await {
-            Ok(Ok(output)) => Ok(ProcessResult {
-                status: output.status,
-                stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-                stderr: String::from_utf8_lossy(&output.stderr).to_string(),
-            }),
-            Ok(Err(e)) => Err(RecordError::Io(e)),
-            Err(_) => Err(RecordError::Other(format!(
-                "Command {cmd_name} timed out after {d:?}"
-            ))),
+    // Drain stdout/stderr in separate tasks so `child` stays exclusively ours
+    // to kill/reap when a timeout fires.
+    let stdout_task = tokio::spawn(read_pipe_to_vec(child.stdout.take()));
+    let stderr_task = tokio::spawn(read_pipe_to_vec(child.stderr.take()));
+
+    let status = if let Some(d) = timeout_duration {
+        match timeout(d, child.wait()).await {
+            Ok(s) => s,
+            Err(_elapsed) => {
+                // Timeout: kill and reap so ffmpeg does not keep consuming the
+                // stream/network/disk as an orphan or zombie.
+                let _ = child.start_kill();
+                let _ = child.wait().await;
+                return Err(RecordError::Other(format!(
+                    "Command {cmd_name} timed out after {d:?}"
+                )));
+            }
         }
     } else {
-        let output = child.wait_with_output().await.map_err(RecordError::Io)?;
-        Ok(ProcessResult {
-            status: output.status,
-            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
-        })
+        child.wait().await
     };
+
+    let status = status.map_err(RecordError::Io)?;
+    let stdout_bytes = stdout_task.await.unwrap_or_default();
+    let stderr_bytes = stderr_task.await.unwrap_or_default();
+
+    let result = Ok(ProcessResult {
+        status,
+        stdout: String::from_utf8_lossy(&stdout_bytes).to_string(),
+        stderr: String::from_utf8_lossy(&stderr_bytes).to_string(),
+    });
 
     match &result {
         Ok(res) if !res.status.success() => {
@@ -457,5 +489,45 @@ impl FfmpegOutput {
     #[must_use]
     pub fn exit_code(&self) -> Option<i32> {
         self.output.status.code()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 正常系: 短時間で終了するコマンドが成功すること（パイプ読み取り含む）。
+    /// クロスプラットフォームで実行され、再構成後の基本パスを検証する。
+    #[tokio::test]
+    async fn test_execute_command_succeeds_fast_command() {
+        #[cfg(unix)]
+        let (cmd, args): (&str, Vec<&str>) = ("true", vec![]);
+        #[cfg(windows)]
+        let (cmd, args): (&str, Vec<&str>) = ("cmd", vec!["/C", "exit", "0"]);
+
+        let result = execute_command(cmd, &args, None).await;
+        assert!(
+            result.is_ok(),
+            "fast command should succeed: {:?}",
+            result.err()
+        );
+        let res = result.expect("fast command succeeds");
+        assert!(res.status.success());
+    }
+
+    /// F22 回帰テスト (Unix): タイムアウト時に子プロセスが強制終了されること。
+    /// `sleep 30` を 100ms タイムアウトで実行し、タイムアウトエラーが返ることを検証する。
+    /// kill_on_drop + start_kill によりプロセスは残留しない。
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_execute_command_kills_child_on_timeout() {
+        let result = execute_command("sleep", &["30"], Some(Duration::from_millis(100))).await;
+
+        let err = result.expect_err("sleep 30 with 100ms timeout must time out");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("timed out"),
+            "expected timeout error, got: {msg}"
+        );
     }
 }

--- a/record-lib/src/record/hibiki.rs
+++ b/record-lib/src/record/hibiki.rs
@@ -378,28 +378,23 @@ fn process_program(program: &HibikiJson, archive_base_path: &str) -> Result<(), 
 ///
 /// This function fetches the list of programs, checks for new episodes,
 /// and downloads them using ffmpeg.
-pub fn record() {
+pub fn record() -> Result<(), RecordError> {
     // Get the base archive path from environment variable. This is critical.
-    let archive_base_path = match ensure_archive_path("hibiki") {
-        Ok(path) => path,
-        Err(e) => {
-            error!("Failed to get archive base path: {e}");
-            std::process::exit(5);
-        }
-    };
+    let archive_base_path = ensure_archive_path("hibiki").map_err(|e| {
+        error!("Failed to get archive base path: {e}");
+        e
+    })?;
 
     let page = 1; // Assuming page is fixed at 1 as per original logic
     let programs_url =
         format!("https://vcms-api.hibiki-radio.jp/api/v1/programs?limit=50&page={page}");
 
     info!("Fetching program list from {programs_url}");
-    let programs: Vec<HibikiJson> = match fetch_and_parse(&programs_url) {
-        Ok(p) => p,
-        Err(e) => {
-            error!("Failed to fetch or parse program list: {e}");
-            std::process::exit(1);
-        }
-    };
+    let programs: Vec<HibikiJson> = fetch_and_parse(&programs_url).map_err(|e| {
+        let msg = format!("Failed to fetch or parse program list: {e}");
+        error!("{msg}");
+        RecordError::Other(msg)
+    })?;
 
     info!(
         "Fetched {} programs. Starting processing...",
@@ -413,6 +408,7 @@ pub fn record() {
         }
     }
     info!("Finished processing all programs.");
+    Ok(())
 }
 
 /// 非同期で単一プログラムを処理
@@ -680,21 +676,25 @@ fn move_to_final_path(working_path: &str, output_path: &str) -> Result<(), Strin
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     hibiki::record_parallel().await;
+///     if let Err(e) = hibiki::record_parallel().await {
+///         eprintln!("hibiki recording failed: {e}");
+///     }
 /// }
 /// ```
+///
+/// # Errors
+///
+/// Returns `RecordError` if the archive path cannot be obtained or the program
+/// list cannot be fetched/parsed. Per-program failures are logged and skipped.
 ///
 /// # Panics
 ///
 /// Panics if semaphore permit acquisition fails (unwraps internally).
-pub async fn record_parallel() {
-    let archive_base_path = match ensure_archive_path("hibiki") {
-        Ok(path) => path,
-        Err(e) => {
-            error!("Failed to get archive base path: {e}");
-            std::process::exit(5);
-        }
-    };
+pub async fn record_parallel() -> Result<(), RecordError> {
+    let archive_base_path = ensure_archive_path("hibiki").map_err(|e| {
+        error!("Failed to get archive base path: {e}");
+        e
+    })?;
 
     let page = 1;
     let programs_url =
@@ -720,27 +720,31 @@ pub async fn record_parallel() {
     let programs: Vec<HibikiJson> = match response {
         Ok(resp) => {
             if !resp.status().is_success() {
-                error!("Failed to fetch program list: HTTP {}", resp.status());
-                std::process::exit(1);
+                let msg = format!("Failed to fetch program list: HTTP {}", resp.status());
+                error!("{msg}");
+                return Err(RecordError::Other(msg));
             }
             let text = match resp.text().await {
                 Ok(t) => t,
                 Err(e) => {
-                    error!("Failed to read response: {e}");
-                    std::process::exit(1);
+                    let msg = format!("Failed to read response: {e}");
+                    error!("{msg}");
+                    return Err(RecordError::Other(msg));
                 }
             };
             match serde_json::from_str::<Vec<HibikiJson>>(&text) {
                 Ok(p) => p,
                 Err(e) => {
-                    error!("Failed to parse program list JSON: {e}");
-                    std::process::exit(1);
+                    let msg = format!("Failed to parse program list JSON: {e}");
+                    error!("{msg}");
+                    return Err(RecordError::Other(msg));
                 }
             }
         }
         Err(e) => {
-            error!("Failed to fetch program list: {e}");
-            std::process::exit(1);
+            let msg = format!("Failed to fetch program list: {e}");
+            error!("{msg}");
+            return Err(RecordError::Other(msg));
         }
     };
 
@@ -778,4 +782,5 @@ pub async fn record_parallel() {
     }
 
     info!("Finished processing all programs.");
+    Ok(())
 }

--- a/record-lib/src/record/hibiki_scraper.rs
+++ b/record-lib/src/record/hibiki_scraper.rs
@@ -345,15 +345,6 @@ impl HibikiScraper {
     }
 }
 
-impl Default for HibikiScraper {
-    fn default() -> Self {
-        Self::new().unwrap_or_else(|_| {
-            log::error!("Failed to create HibikiScraper with default configuration");
-            std::process::exit(1);
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/record-lib/src/streaming/chunk_processor.rs
+++ b/record-lib/src/streaming/chunk_processor.rs
@@ -126,6 +126,10 @@ impl ChunkProcessor {
                 .update_usage(chunk.len())
                 .context("Failed to update memory usage")?;
 
+            // The chunk is now on disk; release its bytes so `current_usage`
+            // reflects live in-flight memory, not cumulative throughput.
+            self.memory_monitor.release(chunk.len());
+
             debug!(
                 "Downloaded {} / {} bytes ({:.1}%)",
                 downloaded_bytes,
@@ -235,6 +239,10 @@ impl ChunkProcessor {
             self.memory_monitor
                 .update_usage(bytes_read)
                 .context("Failed to update memory usage")?;
+
+            // The chunk is flushed to disk; release it so live usage stays
+            // bounded and long streams do not spuriously trip the limit.
+            self.memory_monitor.release(bytes_read);
 
             total_bytes += bytes_read as u64;
             chunk_count += 1;
@@ -650,5 +658,40 @@ mod tests {
 
         // Clean up
         let _ = std::fs::remove_file(&output_path);
+    }
+
+    /// F14/F23 回帰テスト: 累積バイト数がメモリ上限を大きく超えても、
+    /// ライブ（チャンク単位）使用量が上限内であれば長時間ストリームは中断されないこと。
+    /// 従来コードでは `current_usage` が累積で単調増加し、上限到達で確定的中断していた。
+    #[tokio::test]
+    async fn test_long_stream_does_not_abort_on_cumulative_bytes() {
+        let temp_dir = std::env::temp_dir();
+        let output_path = temp_dir.join("test_long_stream_regression.mp3");
+
+        // メモリ上限は小さく（チャンク2個分）設定するが、
+        // 累計では遙かに超えるデータを流す。
+        let memory_monitor = Arc::new(MemoryMonitor::new(CHUNK_SIZE * 2));
+        memory_monitor.start().expect("Failed to start monitoring");
+
+        let processor = ChunkProcessor::new(&output_path, CHUNK_SIZE, memory_monitor.clone());
+
+        // 累計 100 チャンク = CHUNK_SIZE*100 バイト（上限 CHUNK_SIZE*2 を大幅超過）
+        let test_data = vec![0u8; CHUNK_SIZE * 100];
+        let reader = Cursor::new(test_data);
+
+        let result = processor.process_reader(reader).await;
+        assert!(
+            result.is_ok(),
+            "long stream should not abort when live memory is bounded: {:?}",
+            result.err()
+        );
+
+        let stats = result.expect("process_reader should succeed");
+        assert_eq!(stats.bytes_written, (CHUNK_SIZE * 100) as u64);
+        assert_eq!(stats.chunks_processed, 100);
+
+        // Clean up
+        let _ = std::fs::remove_file(&output_path);
+        memory_monitor.stop();
     }
 }

--- a/record-lib/src/streaming/memory_monitor.rs
+++ b/record-lib/src/streaming/memory_monitor.rs
@@ -223,7 +223,37 @@ impl MemoryMonitor {
     /// # Errors
     ///
     /// Returns an error if the update would exceed the memory limit.
+    ///
+    /// # Note
+    ///
+    /// `current_usage` tracks *live* in-flight memory, not cumulative
+    /// throughput. Callers that flush chunks to disk should pair each
+    /// `update_usage` with [`release`](Self::release) so long streams do not
+    /// spuriously trip the limit. Total throughput is accumulated separately
+    /// in `total_bytes`.
     pub fn update_usage(&self, bytes: usize) -> Result<()> {
+        // Check the prospective usage BEFORE mutating so a rejected chunk does
+        // not leave the counter permanently above the limit (which would fail
+        // every subsequent chunk).
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "atomic values are expected to fit in usize on target platforms"
+        )]
+        let current = self.current_usage.load(Ordering::Relaxed) as usize;
+        let prospective = current.saturating_add(bytes);
+
+        if prospective > self.memory_limit {
+            warn!(
+                "Memory limit exceeded: {} bytes > {} bytes",
+                prospective, self.memory_limit
+            );
+            return Err(anyhow::anyhow!(
+                "Memory limit exceeded: {} bytes > {} bytes",
+                prospective,
+                self.memory_limit
+            ));
+        }
+
         self.current_usage
             .fetch_add(bytes as u64, Ordering::Relaxed);
         self.total_bytes.fetch_add(bytes as u64, Ordering::Relaxed);
@@ -235,7 +265,33 @@ impl MemoryMonitor {
             self.chunk_count.load(Ordering::Relaxed)
         );
 
-        self.check_memory_limit()
+        // Surface the 80% warning. Cannot error here: we already bounded usage
+        // above, so `check_memory_limit` only emits the approaching-limit warn.
+        let _ = self.check_memory_limit();
+        Ok(())
+    }
+
+    /// Releases bytes from the current live usage.
+    ///
+    /// Call this after a chunk has been flushed to disk so that `current_usage`
+    /// tracks *live* in-flight memory rather than the cumulative bytes ever
+    /// seen. Without this, long streams monotonically increase `current_usage`
+    /// and spuriously trip the memory limit. Total throughput remains recorded
+    /// in `total_bytes`. Saturates at zero (never underflows/wraps).
+    pub fn release(&self, bytes: usize) {
+        // Compare-exchange loop guards against underflow (and the resulting
+        // wrap to a huge value) if releases ever exceed tracked usage.
+        loop {
+            let current = self.current_usage.load(Ordering::Relaxed);
+            let next = current.saturating_sub(bytes as u64);
+            if self
+                .current_usage
+                .compare_exchange(current, next, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                break;
+            }
+        }
     }
 
     /// Resets the current memory usage to zero.
@@ -495,13 +551,45 @@ mod tests {
 
         monitor.update_usage(500).unwrap();
 
-        // This should fail and ensure resources are tracked
+        // This should fail and ensure resources are tracked. Because the limit
+        // is now checked *before* mutating, the rejected chunk does NOT bump
+        // chunk_count and does NOT corrupt the counter (current stays at 500).
         let result = monitor.update_usage(600);
         assert!(result.is_err());
 
-        // Verify monitoring state is still consistent
+        // Verify monitoring state is still consistent: only the accepted chunk
+        // counts, and usage was not permanently driven over the limit.
         let stats = monitor.get_stats();
-        assert_eq!(stats.chunks_processed, 2);
+        assert_eq!(stats.chunks_processed, 1);
+        assert_eq!(monitor.current_usage(), 500);
+    }
+
+    #[test]
+    fn test_release_decreases_live_usage() {
+        let monitor = MemoryMonitor::new(1024);
+        monitor.start().unwrap();
+
+        monitor.update_usage(512).unwrap();
+        assert_eq!(monitor.current_usage(), 512);
+
+        // Releasing the flushed chunk bounds live memory.
+        monitor.release(512);
+        assert_eq!(monitor.current_usage(), 0);
+
+        // Cumulative throughput is unaffected.
+        assert_eq!(monitor.get_stats().bytes_written, 512);
+    }
+
+    #[test]
+    fn test_release_does_not_underflow() {
+        let monitor = MemoryMonitor::new(1024);
+        monitor.start().unwrap();
+
+        monitor.update_usage(100).unwrap();
+        monitor.release(100);
+        // Releasing more than tracked saturates at 0 instead of wrapping.
+        monitor.release(1_000_000);
+        assert_eq!(monitor.current_usage(), 0);
     }
 
     #[test]

--- a/record-lib/src/utils.rs
+++ b/record-lib/src/utils.rs
@@ -174,8 +174,11 @@ pub fn http_error(status_code: u16, url: &str) -> RecordError {
 ///
 /// # Errors
 ///
-/// Returns `RecordError` if the response status indicates an error (4xx or 5xx).
-/// Note: For status codes 403 and 429, this function will exit the process with code 2.
+/// Returns `RecordError` if the response status indicates an error (4xx or 5xx),
+/// including 403 (forbidden) and 429 (rate limited). The decision to terminate
+/// the process on a fatal status belongs to the application boundary, not the
+/// library — callers receive a structured `HttpError` and may map it to an exit
+/// code there.
 pub fn check_http_status(
     response: &reqwest::blocking::Response,
     url: &str,
@@ -184,18 +187,11 @@ pub fn check_http_status(
 
     if status.is_client_error() || status.is_server_error() {
         let status_code = status.as_u16();
-
-        // Handle specific error codes with custom exit behavior
-        match status_code {
-            403 | 429 => {
-                log::error!("HTTP {status_code} error for {url}. Access denied or rate limited.");
-                log::error!("This application will exit with code 2. Please try again later or check your access permissions.");
-                std::process::exit(2);
-            }
-            _ => {
-                return Err(http_error(status_code, url));
-            }
+        if status_code == 403 || status_code == 429 {
+            log::error!("HTTP {status_code} error for {url}. Access denied or rate limited.");
+            log::error!("Please try again later or check your access permissions.");
         }
+        return Err(http_error(status_code, url));
     }
 
     Ok(())
@@ -210,13 +206,16 @@ pub fn html_parsing_error(url: &str, message: &str) -> RecordError {
     }
 }
 
-/// Checks for HTML parsing errors and handles site structure changes.
+/// Builds an HTML parsing error and logs context for site structure changes.
+///
+/// Returns a structured `HtmlParsingError`; the decision to terminate the
+/// process belongs to the application boundary, not the library.
 #[must_use]
 pub fn handle_html_parsing_error(url: &str, error: &str) -> RecordError {
     log::error!("HTML parsing failed for URL: {url}");
     log::error!("Error: {error}");
-    log::error!("This may indicate a change in the website structure. The application will exit with code 3.");
+    log::error!("This may indicate a change in the website structure.");
     log::error!("Please report this issue so the scraper can be updated.");
 
-    std::process::exit(3);
+    html_parsing_error(url, error)
 }

--- a/record-lib/tests/integration_hibiki.rs
+++ b/record-lib/tests/integration_hibiki.rs
@@ -8,7 +8,7 @@
 
 use mockito::{Mock, ServerGuard};
 use record_lib::record::hibiki_scraper::HibikiScraper;
-use record_lib::utils::{check_http_status, html_parsing_error, http_error, RecordError};
+use record_lib::utils::{check_http_status, html_parsing_error, RecordError};
 
 /// Creates a mock server that returns a specific HTTP status code
 fn create_status_mock(server: &mut ServerGuard, status_code: usize, path: &str) -> Mock {
@@ -230,21 +230,21 @@ fn test_http_status_check_with_403() {
 
     let client = reqwest::blocking::Client::new();
     let url = format!("{}/forbidden", server.url());
-    let _response = client.get(&url).send().expect("Failed to send request");
+    let response = client.get(&url).send().expect("Failed to send request");
 
-    // Note: check_http_status will call process::exit(2) for 403
-    // We can't actually test that in unit tests, but we can verify the error would be created
-    let error = http_error(403, &url);
-    match error {
-        RecordError::HttpError {
+    // 403 is now returned as a structured error (no process::exit), so we can
+    // assert on check_http_status directly.
+    let result = check_http_status(&response, &url);
+    match result {
+        Err(RecordError::HttpError {
             status_code,
             url: error_url,
             ..
-        } => {
+        }) => {
             assert_eq!(status_code, 403);
             assert_eq!(error_url, url);
         }
-        _ => panic!("Expected HttpError"),
+        _ => panic!("Expected HttpError for 403, got {:?}", result),
     }
 }
 
@@ -255,21 +255,21 @@ fn test_http_status_check_with_429() {
 
     let client = reqwest::blocking::Client::new();
     let url = format!("{}/rate-limited", server.url());
-    let _response = client.get(&url).send().expect("Failed to send request");
+    let response = client.get(&url).send().expect("Failed to send request");
 
-    // Note: check_http_status will call process::exit(2) for 429
-    // We can't actually test that in unit tests, but we can verify the error would be created
-    let error = http_error(429, &url);
-    match error {
-        RecordError::HttpError {
+    // 429 is now returned as a structured error (no process::exit), so we can
+    // assert on check_http_status directly.
+    let result = check_http_status(&response, &url);
+    match result {
+        Err(RecordError::HttpError {
             status_code,
             url: error_url,
             ..
-        } => {
+        }) => {
             assert_eq!(status_code, 429);
             assert_eq!(error_url, url);
         }
-        _ => panic!("Expected HttpError"),
+        _ => panic!("Expected HttpError for 429, got {:?}", result),
     }
 }
 

--- a/record-lib/tests/integration_streaming.rs
+++ b/record-lib/tests/integration_streaming.rs
@@ -183,16 +183,22 @@ async fn test_chunk_processing_with_partial_last_chunk() {
 #[tokio::test]
 async fn test_chunk_processing_memory_limit() {
     let output_path = temp_test_path("memory_limit");
-    let memory_monitor = Arc::new(MemoryMonitor::new(CHUNK_SIZE * 5)); // Very low limit
+    // Live-memory cap smaller than a single chunk: the first chunk read must
+    // exceed the cap and abort. Cumulative throughput no longer trips the limit
+    // (see test_long_stream_does_not_abort_on_cumulative_bytes).
+    let memory_monitor = Arc::new(MemoryMonitor::new(CHUNK_SIZE / 2));
     let processor = ChunkProcessor::new(&output_path, CHUNK_SIZE, memory_monitor);
 
-    // Create test data that exceeds limit
+    // Create test data that exceeds the per-chunk live-memory cap.
     let test_data = create_test_data(CHUNK_SIZE * 10);
     let reader = Cursor::new(test_data);
 
     let result = processor.process_reader(reader).await;
 
-    assert!(result.is_err(), "Should fail when memory limit is exceeded");
+    assert!(
+        result.is_err(),
+        "Should fail when a single chunk exceeds the live-memory limit"
+    );
 
     // Cleanup
     let _ = std::fs::remove_file(&output_path);


### PR DESCRIPTION
## 概要

コードレビュー 2026-08-06（53件の検証済み発見、`.omc/research/code-review-2026-08-06.md`）の **Phase 1** として、独立して高ROIな安全修正3件を実装しました。プロジェクトルールに従い**マージせずレビュー待ち**です。

## 対応内容

### F31 — ライブラリ層の `process::exit` 除去（critical） Refs #341
`record-lib`（ライブラリクレート）が本番パスで `std::process::exit` を **10箇所** 呼び出し、`Result` によるエラー伝播を迂回していた問題を解消。
- `utils::check_http_status`（403/429 の `exit(2)`）→ `HttpError` を返す
- `utils::handle_html_parsing_error`（`exit(3)`）→ `HtmlParsingError` を返す
- `hibiki::record` / `record_parallel`（`exit(1)`/`exit(5)` 計7箇所）→ `Result<(), RecordError>` を返す
- `HibikiScraper` の `Default` 実装（失敗時 `exit(1)`、呼び出し元なし）を削除 → フォール可能な `::new()`` を使用
- 終了判定をアプリ境界（`examples/hibiki-toybox.rs`）へ移動
- 結合テストを強化: 403/429 が `check_http_status` を直接検証可能に

→ **ライブラリ/テストコードに `process::exit` は 0件**（例バイナリ＝アプリ境界のみ残存、これは正しい）。

### F22 — ffmpeg タイムアウト時にプロセスを kill Closes #349
`execute_command` がタイムアウト時に ffmpeg を kill せず孤立させていた問題を修正。
- `kill_on_drop(true)` を設定（セーフティネット）
- パイプを別タスクでドレインし `Child` を自前で保持
- タイムアウト時に `start_kill` → `wait` で明示的に kill・リープ

### F14/F23 — メモリ会計修正（累積DL量→生メモリ） Closes #348
`MemoryMonitor.update_usage` が累積バイト数を生メモリとして扱い、デフォルト512MB上限で長時間番組が確定的中断していた問題を修正。
- `update_usage` を「事前チェック → 加算」に変更（拒否時のカウンタ破損を防止）
- 新設 `release(bytes)`（サチュレーション、アンダーフローなし）。`chunk_processor` の両経路でフラッシュ後に呼び出し、`current_usage` をライブメモリに
- `total_bytes` は累積スループットとして維持
- 回帰テスト追加: 2チャンク分の上限で100チャンクのストリームが成功することを検証

### インシデンタル
- `batch_benchmark.rs`: 廃止された `criterion::black_box` → `std::hint::black_box`（`-D warnings` ゲートが develop で失敗していたのを解消）
- `app/src/main.rs` テスト: パス区切り文字のクロスプラットフォーム化（Windows でのみ失敗する既存テスト）

## 検証

| チェック | 結果 |
|---------|------|
| `cargo fmt --all --check` | ✅ |
| `cargo check --workspace --all-targets` | ✅ |
| `cargo clippy --workspace --all-targets -- -D warnings` | ✅ rc=0 |
| `cargo nextest run --workspace` | ✅ 124 passed / 9 skipped（ignored ネットワークテスト） |
| `cargo test --doc` | ✅ |

## 挙動変化の注意

- 403/429 発生時、ライブラリは即座にプロセス終了せず `HttpError` を返すようになります。バッチ内の個別プログラムで 429 が起きた場合、従来は即死でしたが、現在はログ出力後に次プログラムへ進みます（他のプログラムエラーと同等）。**致命的エラーでのバッチ中断ポリシーは F34**（severity ベース）で別途対応予定です。プログラム一覧取得の失敗は従来通り `record()`/`record_parallel()` の `Err` として全体を中断します。

## 次フェーズへの引き継ぎ（別Issue）

- **F30/F37**: アプリ境界での構造化終了コードマッピング（`RecordingError` 統合が必要）
- **F34**: 致命的HTTPエラーでのバッチ中断ポリシー
- Phase 2〜4: エピック #333〜#340 に沿って推進

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: glm 4.7 <noreply@zhipuai.cn>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of network, parsing, and recording errors without abruptly terminating the application.
  - Recording failures are now reported clearly, while successful processing completes normally.
  - Timed-out commands are stopped and cleaned up reliably.
  - Fixed streaming memory tracking so processed data is released and limits are enforced per chunk.
  - Improved compatibility across platforms when handling file paths.
- **Documentation**
  - Clarified asynchronous recording behavior and error handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->